### PR TITLE
test: add conflict_type mismatch and rule priority tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,11 +263,35 @@ jobs:
             exit 1
           }
 
-          # Check files without rules
+          # Check files without rules or with conflict_type mismatch
           if ($env:UNRESOLVED_FILES -match [regex]::Escape($TEST_TXT)) {
-            Write-Output "✅ undefined-rule.txt unresolved (no rule defined)"
+            Write-Output "✅ undefined-rule.txt unresolved (has rule with conflict_type mismatch - should be ignored)"
           } else {
             Write-Output "❌ undefined-rule.txt should remain unresolved"
+            exit 1
+          }
+
+          # === Verify conflict_type mismatch behavior ===
+          Write-Output "`n=== Verifying conflict_type mismatch behavior ==="
+
+          # test.json should be resolved by the FIRST matching rule (line 8-10 in config)
+          # The second rule with wrong conflict_type (deleted-by-us) should be ignored
+          if ($env:RESOLVED_FILES -match [regex]::Escape($TEST_JSON)) {
+            Write-Output "✅ test.json resolved by first matching rule (conflict_type mismatch rule ignored)"
+          } else {
+            Write-Output "❌ test.json should be resolved by the first matching rule"
+            exit 1
+          }
+
+          # === Verify rule priority ===
+          Write-Output "`n=== Verifying rule priority ==="
+
+          # test.md should be resolved with 'ours' strategy from the first matching rule
+          # The later rule with 'theirs' strategy should be ignored
+          if ($env:RESOLVED_FILES -match [regex]::Escape($TEST_MD)) {
+            Write-Output "✅ test.md resolved by first matching rule (later rule ignored)"
+          } else {
+            Write-Output "❌ test.md should be resolved by the first matching rule"
             exit 1
           }
 
@@ -311,10 +335,11 @@ jobs:
           }
 
           # Verify test.md has base version content (ours strategy)
+          # This also verifies rule priority - the first rule (ours) takes precedence over the later rule (theirs)
           $mdContent = Get-Content "$TEST_MD" -Raw
           $expectedMdContent = Get-Content "$TEST_DIR/base-version/test.md" -Raw
           if ($mdContent -eq $expectedMdContent) {
-            Write-Output "✅ test.md has correct base version content (ours)"
+            Write-Output "✅ test.md has correct base version content (ours) - first rule takes precedence"
           } else {
             Write-Output "❌ test.md does not have expected base version content"
             Write-Output "Actual content:"

--- a/__tests__/conflict-resolver-test.yml
+++ b/__tests__/conflict-resolver-test.yml
@@ -65,3 +65,25 @@ rules:
 
   # Note: Files without rules (undefined-rule.txt)
   # will remain unresolved with conflict markers
+
+  # === Test for conflict_type mismatch ===
+  # These rules should NOT match because conflict_type doesn't match actual conflict type
+
+  # test.json is actually both-modified, but rule specifies deleted-by-us
+  # This should NOT resolve the conflict
+  - paths: '__tests__/test-conflict-files/test.json'
+    strategy: 'ours'
+    conflict_type: 'deleted-by-us'
+
+  # undefined-rule.txt is actually both-modified, but rule specifies both-added
+  # This should NOT resolve the conflict
+  - paths: '__tests__/test-conflict-files/undefined-rule.txt'
+    strategy: 'theirs'
+    conflict_type: 'both-added'
+
+  # === Test for rule priority ===
+  # This rule should be ignored because an earlier rule already matches test.md
+  # The earlier rule (line 13-15) with 'ours' strategy should take precedence
+  - paths: '__tests__/test-conflict-files/*.md'
+    strategy: 'theirs'
+    conflict_type: 'both-modified'


### PR DESCRIPTION
## Summary
- Add test cases for conflict_type mismatch behavior
- Add test cases for rule priority when multiple rules match
- Update CI workflow verification steps

## Test scenarios added

### 1. Conflict type mismatch test
Tests that when `paths` match but `conflict_type` doesn't match the actual conflict type, the conflict is not resolved and remains unresolved.

**Test cases:**
- `test.json` with `conflict_type: 'deleted-by-us'` (actual: `both-modified`)
- `undefined-rule.txt` with `conflict_type: 'both-added'` (actual: `both-modified`)

### 2. Rule priority test
Tests that when multiple rules match the same path, the first rule takes precedence.

**Test case:**
- `*.md` files have two rules:
  1. First rule: `strategy: 'ours'` (line 13-15)
  2. Second rule: `strategy: 'theirs'` (added at the end)
- Verifies that the first rule is applied

## Changes
- Updated `__tests__/conflict-resolver-test.yml` to add test rules
- Updated `.github/workflows/ci.yml` to verify the new test behaviors

🤖 Generated with [Claude Code](https://claude.ai/code)