### PR TITLE
refactor: Use ConflictType enum instead of string in ConflictResolveRule

### DIFF
--- a/__tests__/domains/services/conflictAnalyzer.test.ts
+++ b/__tests__/domains/services/conflictAnalyzer.test.ts
@@ -72,12 +72,12 @@ describe('ConflictAnalyzer', () => {
       const rules: ConflictResolveRule[] = [
         {
           targetPathPattern: '*.ts',
-          conflictType: 'both-modified',
+          conflictType: ConflictType.BothModified,
           strategy: ResolutionStrategy.Ours
         },
         {
           targetPathPattern: '*.ts',
-          conflictType: 'deleted-by-us',
+          conflictType: ConflictType.DeletedByUs,
           strategy: ResolutionStrategy.Ours
         }
       ]

--- a/src/domains/value-objects/conflictResolveRule.ts
+++ b/src/domains/value-objects/conflictResolveRule.ts
@@ -1,7 +1,8 @@
 import { ResolutionStrategy } from '@domains/value-objects/resolutionStrategy.js'
+import { ConflictType } from '@domains/value-objects/conflictType.js'
 
 export type ConflictResolveRule = {
   readonly targetPathPattern: string
-  readonly conflictType?: string
+  readonly conflictType?: ConflictType
   readonly strategy: ResolutionStrategy
 }


### PR DESCRIPTION
## Summary
This PR refactors the `ConflictResolveRule` type to use the `ConflictType` enum for better type safety instead of using string literals.

## Changes
- Updated `conflictType` property in `ConflictResolveRule` to use `ConflictType` enum
- Added import for `ConflictType` enum in `conflictResolveRule.ts`
- Updated test cases to use `ConflictType` enum values instead of string literals

## Test Plan
- [x] All existing tests pass
- [x] TypeScript compilation successful (`npx tsc --noEmit`)