### PR TITLE
chore: ignore typescript major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,11 @@ updates:
       - dependency-name: '@types/node'
         update-types:
           - 'version-update:semver-major'
+      # TypeScript 7 is not yet supported by @typescript-eslint (<6.1.0) or
+      # ts-jest (<7). Remove this once the ecosystem catches up.
+      - dependency-name: 'typescript'
+        update-types:
+          - 'version-update:semver-major'
     groups:
       npm-development:
         dependency-type: development


### PR DESCRIPTION
## Summary

Dependabot PR #159 (typescript 6.0.3 → 7.0.2) cannot pass CI because the toolchain does not support TypeScript 7 yet:

| Package | Supported TypeScript range |
|---|---|
| `@typescript-eslint/eslint-plugin` (latest 8.67.0, incl. canary) | `>=4.8.4 <6.1.0` |
| `ts-jest` (latest 29.4.12) | `>=4.3 <7` |

`npm ci` fails with `ERESOLVE` before any build/test step runs, so there is nothing to fix on our side.

This PR adds `typescript` to the Dependabot `ignore` list for `semver-major` updates, following the existing `@types/node` pattern. Minor/patch updates on 6.x will still be proposed.

**Remove this ignore entry once @typescript-eslint and ts-jest support TypeScript 7.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdZEADrDsqLu4jLBvF4gi6